### PR TITLE
Ignored invalid verses instead of raising an exception

### DIFF
--- a/lib/pericope.rb
+++ b/lib/pericope.rb
@@ -214,7 +214,13 @@ private
   def group_array_into_ranges(verses)
     return [] if verses.nil? or verses.empty?
 
-    verses = verses.flatten.compact.sort.map { |verse| Verse.parse(verse) }
+    verses = verses.flatten.compact.sort.each_with_object([]) do |verse, verses|
+      begin
+        verses << Verse.parse(verse)
+      rescue ArgumentError
+        # skip invalid verses
+      end
+    end
 
     ranges = []
     range_begin = verses.shift

--- a/test/pericope_test.rb
+++ b/test/pericope_test.rb
@@ -428,18 +428,17 @@ class PericopeTest < Minitest::Test
           assert_equal expected_pericope, Pericope.new(verses).ranges
         end
       end
+
+      should "ignore invalid verses" do
+        # Psalm 117:3 does not exist
+        assert_equal [r(19117001, 19117002)], Pericope.new(%w{19117001 19117002 19117003}).ranges
+      end
     end
 
     context "#to_a" do
       should "return an array of verses" do
         @tests.each do |reference, expected_verses|
           assert_equal expected_verses, Pericope(reference).to_a.map(&:to_id), "Given #{reference}"
-        end
-      end
-
-      should "raise an exception if pass an invalid verse" do
-        assert_raises ArgumentError do
-          Pericope.new([67001001])
         end
       end
     end


### PR DESCRIPTION
This PR isn't a 🚒, just wondering which you think is the better behavior: before or after?