### PR TITLE
Handled a reference where a period was used in place of a comma

### DIFF
--- a/lib/pericope.rb
+++ b/lib/pericope.rb
@@ -127,7 +127,7 @@ class Pericope
 
     def normalizations
       @_normalizations ||= [
-        [/(\d+)[".](\d+)/, '\1:\2'],        # 12"5 and 12.5 -> 12:5
+        [/(\d+)\s*[".]\s*(\d+)/, '\1:\2'],  # 12"5 and 12.5 -> 12:5
         [/[–—]/,           '-'],            # convert em dash and en dash to -
         [/[^0-9,:;\-–—#{letters}]/,  ''] ]  # remove everything but recognized symbols
     end

--- a/pericope.gemspec
+++ b/pericope.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.default_executable = "pericope"
   s.require_path = "lib"
 
-  s.add_development_dependency "bundler", "~> 1.10"
-  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "bundler"
+  s.add_development_dependency "rake"
   s.add_development_dependency "shoulda-context"
   s.add_development_dependency "pry"
   s.add_development_dependency "minitest", "~> 5.0"

--- a/test/pericope_test.rb
+++ b/test/pericope_test.rb
@@ -226,6 +226,16 @@ class PericopeTest < Minitest::Test
         assert_equal [r(19001001, 19001006)], pericope.ranges
       end
 
+      should "handle oddly-formed references" do
+        tests = {
+          "Psa 40:3-4, 7-11. 16" => "Psalm 40:3–4, 7–16"
+        }
+
+        tests.each do |input, expected_pericope|
+          assert_equal expected_pericope, Pericope.parse_one(input).to_s, "Expected \"#{input}\" to yield pericope for \"#{expected_pericope}\""
+        end
+      end
+
       should "return nil for an invalid reference" do
         assert_nil Pericope.parse_one("nope")
       end


### PR DESCRIPTION
The example that broke Pericope is included in the newly-created test. It _seems_ alright to me to interpret the period in this way; the only conflict I could see would be if someone was using period to divide chapter and verse but also included a space between, e.g., `Romans 12. 1-2`. In this case, the reference would be coerced to `12,1-2` ... which is still probably better than what was happening before where it was coerced to the indecipherable `121-2`. 😅 

In any case, the rule would now be that without a space, it's interpreted as dividing chapter and verse, but with the space it's interpreted as dividing verses. This seems like the right behavior to me (or closer to it), but what do you think? Am I missing something?