### PR TITLE
Whole chapter verses ... sometimes

### DIFF
--- a/lib/pericope.rb
+++ b/lib/pericope.rb
@@ -177,6 +177,8 @@ private
     recent_chapter = 1 unless book_has_chapters?
     recent_verse = nil
 
+    touched_chapters = [ recent_chapter ].compact
+
     ranges.each_with_index.each_with_object("") do |(range, i), s|
       if i > 0
         if recent_chapter == range.begin.chapter
@@ -187,7 +189,7 @@ private
       end
 
       last_verse = Pericope.get_max_verse(book, range.end.chapter)
-      if !always_print_verse_range && range.begin.verse == 1 && range.begin.whole? && (range.end.verse > last_verse || range.end.whole? && range.end.verse == last_verse)
+      if !always_print_verse_range && range.begin.verse == 1 && range.begin.whole? && (range.end.verse > last_verse || range.end.whole? && range.end.verse == last_verse) && (touched_chapters - [range.begin.chapter]).none?
         s << range.begin.chapter.to_s
         s << "#{chapter_range_separator}#{range.end.chapter}" if range.end.chapter > range.begin.chapter
       else
@@ -207,6 +209,7 @@ private
 
         recent_chapter = range.end.chapter
         recent_verse = range.end.verse if range.end.partial?
+        touched_chapters |= [range.begin.chapter, range.end.chapter].uniq
       end
     end
   end

--- a/test/pericope_test.rb
+++ b/test/pericope_test.rb
@@ -300,6 +300,9 @@ class PericopeTest < Minitest::Test
         assert_equal "Jude 1–25", Pericope("Jude 1–25").to_s
       end
 
+      should "not omit verses when describing a whole chapter along with verses from another chapter" do
+        assert_equal "Genesis 2:8–9; 3:1–24", Pericope("Genesis 2:8-9, 3:1-24").to_s
+      end
 
       should "allow customizing :verse_range_separator" do
         assert_equal "John 1:1_7", Pericope.new("john 1:1-7").to_s(verse_range_separator: "_")


### PR DESCRIPTION
### Summary

This was an issue where the well-formatted reference ended up being "Genesis 2:8-9; 3", which when parsed back into Pericope ended up as "Genesis 2:8-9, 3" (verse 3 instead of chapter 3). It seemed more fraught to try to scale back some of the generosity of the parsing engine to parse the reference correctly than it would be to tweak the output rules to clarify the entirety of the chapter, which seems to be the way references would want to be displayed in such cases anyhow.